### PR TITLE
Added jsonpath support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,82 @@
 # jexi
-Jexi is a lisp interpreter with no lisp only json! 
+Jexi is all about "executable JSON"
+
+"Jexi" stands for 'json expression interpreter'
+
+The key ideas in Jexi are:
+
+* Jexi embraces lisp's "code is data" philosophy except that in Jexi "code is JSON"
+
+  (Jexi is a really lisp interpreter reimagined using JSON)
+
+* Since JSON is language neutral the hope is that Jexi interpreters written in multiple languages might be created in the future
+
+  (this version is in javascript and is tested in node.js and the browser)
+
+* Since Jexi code is JSON it can be easily stored and manipulated e.g. in MongoDB, sent over the wire via api calls, etc.
+
+* Jexi code might be ideal for saving from GUIs ala Low-Code/No-Code solutions
+
+* since JSON has no notion of "symbols" in Jexi function/variable/etc. names are simply strings that start with "$"
+
+* whereas in lisp functions are called like:
+
+   `(fname arg1 ... argN)`
+
+  In Jexi the canonical way to invoke functions are using a single key object like:
+  
+    `{ "$fname": [ arg1, ..., argN ] }`
+
+  i.e. where in lisp you write: `(+ 1 1)`
+
+  in Jexi you write: `{ "$+": [ 1, 1 ] }`
+
+  you can think of single "$" key objects like the above as Jexi's *o-expression* answer to Lisp *s-expressions*  
+
+* Jexi encourages named arguments (ala Smalltalk) using JSON object keys like:
+
+  `{ "$fname": { "argname1": arg1, ..., "argnameN": argN } }`
+
+  e.g. 
+  
+  ```
+  {
+    "$foreach": {
+      "in": [ 0, 1, 2 ],
+      "as": "$elem",
+      "do": {
+        "$console.log": "$elem"
+      }
+    }
+  }
+  ```
+
+  for clarity a function such as the above is referred to as `$foreach/in/as/do`
+
+  note that by convention the function name `$foreach` is prefixed with `$` but the named arguments (i.e. `in`, `as`, `do`) are not
+
+  names preceded with `$` are variables resolved within the environment (e.g. `$foreach` is a function resolved in the environment while `in`, `as`, and `do` are not)
+
+* A repl is provided here that can be starte with:
+
+  `npm run repl`
+
+  The repl makes use of the "really-relaxed-json" package which allows you to omit the extra quotes on symbols to read nicer (more like JSON in a javascript file allows - in really-relaxed-json even goes further e.g. making commas optional):
+
+  ```
+  {
+    $foreach: {
+      in: [ 0 1 2 ]
+      as: $elem
+      do: {
+        $console.log: $elem
+      }
+    }
+  }
+  ```
+
+  In the repl you can snoop at the current environment by typing: `$env`
+
+  And if you'd like to enable tracing to see what Jexi is doing you can do:
+
+  `{ $set: { $options.trace: true } }`

--- a/examples/jsonpath.jexi
+++ b/examples/jsonpath.jexi
@@ -1,0 +1,106 @@
+{
+  $do: [
+    {
+      $set: {
+        $bookStore: {
+          store: {
+            book: [
+              {
+                category: reference
+                author: 'Nigel Rees'
+                title: 'Sayings of the Century'
+                price: 8
+              }
+              {
+                category: fiction
+                author: 'Evelyn Waugh'
+                title: 'Sword of Honour'
+                price: 12
+              }
+              {
+                category: fiction
+                author: 'Herman Melville'
+                title: 'Moby Dick'
+                isbn: '0-553-21311-3'
+                price: 8
+              }
+              {
+                category: fiction
+                author: 'J. R. R. Tolkien'
+                title: 'The Lord of the Rings'
+                isbn: '0-395-19395-8'
+                price: 22
+              }
+            ]
+            bicycle: {
+              color: red
+              price: 19
+            }
+          }
+        }
+        $examples: [
+          {
+            path: '$.store.book[*].author'
+            description: 'the authors of all books in the store'
+          }
+          {
+            path: $..author
+            description: 'all authors'
+          }
+          {
+            path: '$.store.*'
+            description: 'all things in store, which are some books and a red bicycle'
+          }
+          {
+            path: $.store..price
+            description: 'the price of everything in the store'
+          }
+          {
+            path: '$..book[2]'
+            description: 'the third book'
+          }
+          {
+            path: '$..book[-1:]'
+            description: 'the last book in order'
+          }
+          {
+            path: '$..book[0,1]'
+            description: 'the first two books'
+          }
+          {
+            path: '$..book[?(@.isbn)]'
+            description: 'filter all books with isbn number'
+          }
+          {
+            path: '$..book[?(@.price<10)]'
+            description: 'filter all books cheapier than 10'
+          }
+          {
+            path: '$..*'
+            description: 'All members of JSON structure'
+          }
+        ]
+      }
+    }
+    {
+      $foreach: {
+        in: $examples
+        as: $example
+        do: {
+          $console.log: [
+            $example.path
+            (
+            $example.description
+            ') ='
+            {
+              $jsonpath: {
+                path: $example.path
+                in: $bookStore
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/examples/jsonpath.json
+++ b/examples/jsonpath.json
@@ -1,0 +1,106 @@
+{
+  "$do": [
+    {
+      "$set": {
+        "$bookStore": {
+          "store": {
+            "book": [
+              {
+                "category": "reference",
+                "author": "Nigel Rees",
+                "title": "Sayings of the Century",
+                "price": 8
+              },
+              {
+                "category": "fiction",
+                "author": "Evelyn Waugh",
+                "title": "Sword of Honour",
+                "price": 12
+              },
+              {
+                "category": "fiction",
+                "author": "Herman Melville",
+                "title": "Moby Dick",
+                "isbn": "0-553-21311-3",
+                "price": 8
+              },
+              {
+                "category": "fiction",
+                "author": "J. R. R. Tolkien",
+                "title": "The Lord of the Rings",
+                "isbn": "0-395-19395-8",
+                "price": 22
+              }
+            ],
+            "bicycle": {
+              "color": "red",
+              "price": 19
+            }
+          }
+        },
+        "$examples": [
+          {
+            "path": "$.store.book[*].author",
+            "description": "the authors of all books in the store"
+          },
+          {
+            "path": "$..author",
+            "description": "all authors"
+          },
+          {
+            "path": "$.store.*",
+            "description": "all things in store, which are some books and a red bicycle"
+          },
+          {
+            "path": "$.store..price",
+            "description": "the price of everything in the store"
+          },
+          {
+            "path": "$..book[2]",
+            "description": "the third book"
+          },
+          {
+            "path": "$..book[-1:]",
+            "description": "the last book in order"
+          },
+          {
+            "path": "$..book[0,1]",
+            "description": "the first two books"
+          },
+          {
+            "path": "$..book[?(@.isbn)]",
+            "description": "filter all books with isbn number"
+          },
+          {
+            "path": "$..book[?(@.price<10)]",
+            "description": "filter all books cheapier than 10"
+          },
+          {
+            "path": "$..*",
+            "description": "All members of JSON structure"
+          }
+        ]
+      }
+    },
+    {
+      "$foreach": {
+        "in": "$examples",
+        "as": "$example",
+        "do": {
+          "$console.log": [
+            "$example.path",
+            "(",
+            "$example.description",
+            ") =",
+            {
+              "$jsonpath": {
+                "path": "$example.path",
+                "in": "$bookStore"
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
+        "jsonpath-plus": "^7.2.0",
         "lodash.castarray": "4.4.0",
         "lodash.get": "4.4.2",
         "lodash.set": "4.3.2",
@@ -7150,6 +7151,14 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/jsprim": {
@@ -15790,6 +15799,11 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.2.tgz",
       "integrity": "sha512-46Tk9JiOL2z7ytNQWFLpj99RZkVgeHf87yGQKsIkaPz1qSH9UczKH1rO7K3wgRselo0tYMUNfecYpm/p1vC7tQ==",
       "dev": true
+    },
+    "jsonpath-plus": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-7.2.0.tgz",
+      "integrity": "sha512-zBfiUPM5nD0YZSBT/o/fbCUlCcepMIdP0CJZxM1+KgA4f2T206f6VAg9e7mX35+KlMaIc5qXW34f3BnwJ3w+RA=="
     },
     "jsprim": {
       "version": "1.4.2",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/darrencruse/jexi#readme",
   "dependencies": {
+    "jsonpath-plus": "^7.2.0",
     "lodash.castarray": "4.4.0",
     "lodash.get": "4.4.2",
     "lodash.set": "4.3.2",


### PR DESCRIPTION
Using package jsonpath-plus

That actually went well but when I went to add the new example here "jsonpath.jexi" it did reveal some issues that I resolved for now

(but those do raise some design questions I noted in the comments re whether Jexi should default to working like a "template" language i.e. where you can place { $fn } expressions anywhere up and down the json and have them automatically reduce to their values to produce a proper json or whether things are better served by that *not* being the default but more something you'd enable as an option)

Related to the above I've taken a first stab at handling "$quote"/"$json" but I'd like to revisit those and see if I can have proper quote/quasiquote/unquote working (like for templatea/macros)
   