### PR TITLE
added an example fetching two apis joined using jsonata

### DIFF
--- a/examples/fetchjoin.jexi
+++ b/examples/fetchjoin.jexi
@@ -1,0 +1,19 @@
+[
+  {
+    $var: {
+      $users: { $fetch: 'https://jsonplaceholder.typicode.com/users' },
+      $posts: { $fetch: 'http://jsonplaceholder.typicode.com/posts' },
+    },
+  },
+  {
+    $jsonata: "posts@$P.users@$U[$P.userId=$U.id].{\
+      'userId': $U.id,\
+      'user': $U.name,\
+      'userName': $U.username,\
+      'email': $U.email,\
+      'postId': $P.id,\
+      'title': $P.title,\
+      'body': $P.body\
+    }"
+  }
+]

--- a/src/registry.js
+++ b/src/registry.js
@@ -263,6 +263,7 @@ export default {
       // we intentionally evaluate to undefined here
       // because $var defining a function was getting called
       // at the declaration
+      // TBD this seems surprising shouldn't this return the last declaration's value?
       return undefined
     },
 


### PR DESCRIPTION
another small example here

(didn't bother including a .json version this time - as I get more used to the ".jexi" format not sure it's helpful having both)
