### PR TITLE
Add missing method ish handler

### DIFF
--- a/bin/jexi.js
+++ b/bin/jexi.js
@@ -1,11 +1,11 @@
 #!/usr/bin/env NODE_TLS_REJECT_UNAUTHORIZED=0 node
 
-import { interpreter } from '../src/index.js'
+import { jexiInterpreter } from '../src/index.js'
 import { startRepl } from '../src/repl.js'
 
 // if they gave a filename:
 if (process.argv.length > 2 && !process.argv[2].startsWith('-')) {
-  const jexi = interpreter({}, { trace: false })
+  const jexi = jexiInterpreter({}, { trace: false })
 
   // run it
   const result = await jexi.evaluate({ $run: process.argv[2] })
@@ -18,7 +18,7 @@ if (process.argv.length > 2 && !process.argv[2].startsWith('-')) {
   // imagining the repl will have it's own custom commands later on:
   const extensions = {}
 
-  const jexi = interpreter(extensions, { trace: false })
+  const jexi = jexiInterpreter(extensions, { trace: false })
 
   startRepl(jexi, jexi.createEnv())
 }

--- a/examples/foreach.jexi
+++ b/examples/foreach.jexi
@@ -1,0 +1,10 @@
+{
+  // most quotes (and even commas) are optional:
+  // and yes comments (such as this one :) are allowed
+  $foreach: [ 0 1 2 ]
+  as: $elem
+  do: {
+    $console.log: $elem
+  }
+}
+

--- a/examples/foreach.json
+++ b/examples/foreach.json
@@ -1,0 +1,8 @@
+{
+  "$foreach": [ 0, 1, 2 ],
+  "as": "$elem",
+  "do": {
+    "$console.log": "$elem"
+  }
+}
+

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const getRegistryTable = (registry, tableKey, typeFlag = '') => {
 // extensions are a registry with keys of plainFunctions/keywordArgs/specialForms/macros/globals
 // (extensions add to the builtins to create the initial environment)
 // options are { trace: true|false } (more options to come)
-export const interpreter = (extensions = {}, options = {}) => {
+export const jexiInterpreter = (extensions = {}, options = {}) => {
   // options.trace = true
 
   const globalEnv = {
@@ -32,18 +32,19 @@ export const interpreter = (extensions = {}, options = {}) => {
     ...getRegistryTable(builtins, 'keywordArgs', '_keyword'),
     ...getRegistryTable(builtins, 'macros', '_macro'),
     ...getRegistryTable(builtins, 'plainFunctions', '_plain'),
+    ...getRegistryTable(builtins, 'handlers'),
     ...getRegistryTable(builtins, 'globals'),
 
     // note extensions can override builtins of the same name if they choose
     ...getRegistryTable(extensions, 'specialForms', '_special'),
     ...getRegistryTable(extensions, 'keywordArgs', '_keyword'),
     ...getRegistryTable(extensions, 'macros', '_macro'),
+    ...getRegistryTable(extensions, 'handlers'),
     ...getRegistryTable(extensions, 'plainFunctions', '_plain'),
-    ...getRegistryTable(extensions, 'globals'),
   }
 
   // eslint-disable-next-line no-console
-  const trace = (...args) => globalEnv.options.trace && console.log.apply(null, args)
+  const trace = (...args) => globalEnv.options.trace && globalEnv.log(...args)
 
   // map an async function to each element of the array, 
   // waiting for each to complete before doing the next 
@@ -114,20 +115,6 @@ export const interpreter = (extensions = {}, options = {}) => {
     return evaluate(JSON.parse(jsonStr), env)
   }
 
-  // this is the instance of the interpreter we return customized according
-  // to the extensions they pass into the interpreter() creation function
-  const theInterpreter = {
-    evaluate,
-    evalJexiStr,
-    trace,
-    createEnv,
-    globals: globalEnv,
-    isSymbol,
-    getFnSymbolForForm,
-    symbolToString,
-    stringToSymbol,
-  }
-
   const evaluateKeys = async (oform, env) => {
     // note it's important here to make a new object and not mutate the incoming form
     // (which may get reused e.g. in the body of a for/map/etc.)
@@ -139,6 +126,21 @@ export const interpreter = (extensions = {}, options = {}) => {
     }
 
     return evaluatedForm
+  }
+
+  // this is the instance of the interpreter we return customized according
+  // to the extensions they pass into the jexiInterpreter() creation function
+  const theInterpreter = {
+    evaluate,
+    evalJexiStr,
+    evaluateKeys,
+    trace,
+    createEnv,
+    globals: globalEnv,
+    isSymbol,
+    getFnSymbolForForm,
+    symbolToString,
+    stringToSymbol,
   }
 
   // an object form is { $fnSymbol: [ arg1 ... argN ] }
@@ -198,24 +200,16 @@ export const interpreter = (extensions = {}, options = {}) => {
         return func(...evaluatedArgs)
       }
 
-      // TBD this should probably change to being an error...
-      // i.e. this is more likely a typo than an intention to pass thru data with $ in a key?
-      trace(`evaluateObjectForm: passing thru object with unrecognized symbol key "${$fnSymbol}":`, JSON.stringify(oform, null, 2))
+      // their $fn symbol key did not resolve in the environment
+      return env.onNotFound(oform, env, theInterpreter)
     }
 
-    // note the following may be bad for performance with large payloads
-    // they can use $quote/$json to mark data they know doesn't need to evaluated
-    // TBD is defaulting to evaluating everything the best though?  could I
-    //  have e.g. "$template" to indicate eval is needed everywhere but not 
-    //  do that by default (maybe I use $ even on keyword arguments and only 
-    //  evaluate those when not within a "$template"?)
-
-    trace('evaluateObjectForm: evaluating key values of plain object as a template')
-
-    return evaluateKeys(oform, env)
+    // no $fn symbol key found on the object
+    // "onPlainJson" is an optional handler client code can use to intercept and process such non-jexi json:
+    return env.onPlainJson(oform, env, theInterpreter)
   }
 
   return theInterpreter
 }
 
-export default interpreter
+export default jexiInterpreter

--- a/src/index.js
+++ b/src/index.js
@@ -143,6 +143,18 @@ export const jexiInterpreter = (extensions = {}, options = {}) => {
     stringToSymbol,
   }
 
+  // invoke their custom "handler" (if they've overriden ours) but if it returns undefined
+  // fallback to our default behavior (i.e. invoke our builtin handler after all) 
+  const invokeHandler = (handlerName, oform, env, theInterpreter) => {
+    let handlerResult = env[handlerName](oform, env, theInterpreter)
+
+    if (handlerResult === undefined && env[handlerName] !== builtins.handlers[handlerName]) {
+      handlerResult = builtins.handlers[handlerName](oform, env, theInterpreter)
+    }
+
+    return handlerResult
+  }
+
   // an object form is { $fnSymbol: [ arg1 ... argN ] }
   // or (for convenience) { $fnSymbol: arg } when there is only one argument
   // eslint-disable-next-line no-unused-vars
@@ -201,12 +213,12 @@ export const jexiInterpreter = (extensions = {}, options = {}) => {
       }
 
       // their $fn symbol key did not resolve in the environment
-      return env.onNotFound(oform, env, theInterpreter)
+      return invokeHandler('onNotFound', oform, env, theInterpreter)
     }
 
     // no $fn symbol key found on the object
     // "onPlainJson" is an optional handler client code can use to intercept and process such non-jexi json:
-    return env.onPlainJson(oform, env, theInterpreter)
+    return invokeHandler('onPlainJson', oform, env, theInterpreter)
   }
 
   return theInterpreter

--- a/test/jexiTestHelpers.js
+++ b/test/jexiTestHelpers.js
@@ -1,6 +1,6 @@
-import { interpreter } from '../src/index.js'
+import { jexiInterpreter } from '../src/index.js'
 
-const jexi = interpreter({}, { trace: false })
+const jexi = jexiInterpreter({}, { trace: false })
 
 // for testing with json forms:
 export const $eval = (form, env) => jexi.evaluate(form, env)


### PR DESCRIPTION
decided to break this into two similar (but slightly different) trap "handlers":

    // onNotFound is called when jexi encounters a json form with a "$fn" key where "fn" is
    // not found in the environment (analous to e.g. "missing method" in other languages)
    'onNotFound': (jsonForm, env, { getFnSymbolForForm, trace }) => {

and

    // onPlainJson is called when jexi encounters a json form that has no "$fn" symbol key
    // and is therefore assumed to be plain json data.  This handler allows client code to
    // customize how such json is processed (by default we treat it as a json template that
    // might have jexi forms nested within it)
    'onPlainJson': (jsonData, env, { evaluateKeys, trace }) => {
    
for onNotFound: it doesn't yet but by default may very well change later to throw an error (or maybe a "strict mode" boolean in the globals can say if it should error or be permissive like it does now)

for onPlainJson: by default it treats the json like a template and processes the json beneath for $fn style jexi calls.

for both if they've installed a custom handler but it returns undefined then we take it as their way of saying they want us to apply the default behavior.
