### PR TITLE
break out node specific registry to avoid webpack errors

### DIFF
--- a/bin/jexi.js
+++ b/bin/jexi.js
@@ -2,10 +2,11 @@
 
 import { jexiInterpreter } from '../src/index.js'
 import { startRepl } from '../src/repl.js'
+import nodeSpecificExtensions from '../src/non-browser.js'
 
 // if they gave a filename:
 if (process.argv.length > 2 && !process.argv[2].startsWith('-')) {
-  const jexi = jexiInterpreter({}, { trace: false })
+  const jexi = jexiInterpreter(nodeSpecificExtensions, { trace: false })
 
   // run it
   const result = await jexi.evaluate({ $run: process.argv[2] })
@@ -15,8 +16,8 @@ if (process.argv.length > 2 && !process.argv[2].startsWith('-')) {
   // eslint-disable-next-line no-console
   console.log('Starting Jexi REPL...')
 
-  // imagining the repl will have it's own custom commands later on:
-  const extensions = {}
+  // imagining the repl may have additional commands (as extensions) later on:
+  const extensions = nodeSpecificExtensions
 
   const jexi = jexiInterpreter(extensions, { trace: false })
 

--- a/src/non-browser.js
+++ b/src/non-browser.js
@@ -1,0 +1,69 @@
+import { readFile } from 'fs/promises'
+import RJson from 'really-relaxed-json'
+import yargs from 'yargs'
+
+const rjsonParser = RJson.createParser()
+
+//
+// Registry of browser-incompatible extensions
+//
+// note by keeping the below dependencies here (and out of the "builtins" registry.js)
+// we avoid errors with browser bundlers like webpack (over e.g. readFile and yargs
+// which don't have browser equivalents)
+//
+// these are installed in bin/jexi.js for command line/repl use but not referenced
+// elsewhere so that browser bundlers don't include these.
+//
+const nodeSpecificExtensions = {
+  plainFunctions: {
+    // $read = read a .json or .jexi file's contents as JSON
+    // e.g. read contents of data.json: { $read: 'examples/data.json' }
+    // e.g. read contents of geodata.jexi converted to JSON: { $read: 'examples/geodata.jexi' }
+    read: async filepath => {
+      // eslint-disable-next-line no-unused-vars
+      const [ _wholepath, _filepath, filename, extension ] =
+        filepath.trim().match(/^(.+?\/)?([^./]+)(\.[^.]*$|$)/)
+      let contentsStr = ''
+
+      try {
+        contentsStr = await readFile(filepath, { encoding: 'utf8' })
+      } catch (err) {
+        throw new Error(`Could not read file '${filepath}': ${err}`)
+      }
+
+      let forms = null
+
+      try {
+        // note if there's no file extension we still run relaxed-json
+        // (if it's JSON it just comes thru unchanged) 
+        const jsonStr = !extension || extension === '.jexi' ?
+          rjsonParser.stringToJson(contentsStr) :
+          contentsStr
+
+        forms = JSON.parse(jsonStr)
+      } catch (err) {
+        throw new Error(`The file '${filepath}' contains invalid JSON: ${err}`)
+      }
+
+      return forms
+    },
+  },
+
+  macros: {
+    // $getparameters = get provided input parameters into the environment (as "$parameters" by default)
+    // e.g. { $getparameters: [{ alias: "name", describe: "Your name", type: "string", demandOption: true }] }
+    getparameters: ({ $getparameters: options }) => {
+      const parameters = yargs(process.argv.slice(2))
+        .usage(`Usage: $0 ${process.argv[2]} ${options.map(opt => `--${opt.alias} [${opt.type}]`).join(' ')}`)
+        .demandOption(options.reduce((accum, opt) => opt.demandOption ? [ ...accum, opt.alias ] : accum, []))
+        .argv
+
+      delete parameters._
+      delete parameters.$0
+
+      return { $set: { $parameters: parameters }}
+    },
+  },
+}
+
+export default nodeSpecificExtensions

--- a/test/jexiTestHelpers.js
+++ b/test/jexiTestHelpers.js
@@ -1,6 +1,7 @@
 import { jexiInterpreter } from '../src/index.js'
+import nodeSpecificExtensions from '../src/non-browser.js'
 
-const jexi = jexiInterpreter({}, { trace: false })
+const jexi = jexiInterpreter(nodeSpecificExtensions, { trace: false })
 
 // for testing with json forms:
 export const $eval = (form, env) => jexi.evaluate(form, env)


### PR DESCRIPTION
ran into problems using jexi from a browser app using webpack

tried a myriad of solutions and ultimately did get it work by adding this into webpack.config.js:
```
    externals: {
      'fs/promises': 'stop',
      yargs: 'stop',
    },
```

but (after sleeping on it :) I realized the solution here is much better in which I've broken a separate "extensions"/"registry" holding a couple of the $fn functions that really only made sense from node/command-line anyway.

so now the main "registry.js" file holds only things that are cross-browers/node compatible

and the new file "non-browser.js" is this separate mini-"registry" of the extension that don't/can't work in the browser (initially it was $read for reading from a file and $getparameters for processing command line parameters)